### PR TITLE
check if build/ exists and delete before building hercules

### DIFF
--- a/01_sysgen_build_hercules.sh
+++ b/01_sysgen_build_hercules.sh
@@ -5,6 +5,7 @@ trap 'check_return' 0
 set -e
 
 echo_step "Building external packages"
+if [ -d "build" ]; then rm -rf build/; fi
 mkdir build
 cd build
 mkdir ./hercpkgs


### PR DESCRIPTION
build/ needs to be deleted before building hercules, otherwise second executiong of sysgen.sh with hercules build will fail. 