### PR TITLE
added 2 extra readers and one extra punch

### DIFF
--- a/sysgen/conf/local.cnf
+++ b/sysgen/conf/local.cnf
@@ -35,6 +35,7 @@ PANOPT MSGCOLOR=DARK
 # V     V       V
 #---    ----    --------------------------------- card readers
 000C    3505    localhost:3505 sockdev autopad trunc ascii eof
+001A    3505    localhost:3506 sockdev autopad trunc ebcdic eof
 001C    3505    jcl/null.jcl eof
 # ----------------------------------------------- card punches & printers
 000D    3525    pch00d.txt ebcdic          # JES2

--- a/sysgen/jcl/sysgen02.jcl
+++ b/sysgen/jcl/sysgen02.jcl
@@ -118,8 +118,8 @@ INTRDR CLASS=A,NOHOLD,AUTH=0,PRIOINC=0,PRIOLIM=15
 &NUMINRS=5                     NUMBER OF INTERNAL READERS               
 &NUMJOES=1024                  NUMBER OF JOB OUTPUT ELEMENTS            
 &NUMPRTS=3                     MAX NUMBER OF LOCAL PRINTERS             
-&NUMPUNS=1                     MAX NUMBER OF LOCAL PUNCHES              
-&NUMRDRS=2                     MAX NUMBER OF LOCAL READERS              
+&NUMPUNS=2                     MAX NUMBER OF LOCAL PUNCHES              
+&NUMRDRS=3                     MAX NUMBER OF LOCAL READERS              
 &NUMSMFB=96                    NUMBER OF SMF BUFFERS                    
 &NUMTGV=3330                   TRACK GROUPS PER SPOOL VOLUME (3350)     
 &OUTPOPT=0                     ACTION FOR JOBS EXCEEDING OUTPUT         

--- a/sysgen/jcl/sysgen02.jcl
+++ b/sysgen/jcl/sysgen02.jcl
@@ -119,7 +119,7 @@ INTRDR CLASS=A,NOHOLD,AUTH=0,PRIOINC=0,PRIOLIM=15
 &NUMJOES=1024                  NUMBER OF JOB OUTPUT ELEMENTS            
 &NUMPRTS=3                     MAX NUMBER OF LOCAL PRINTERS             
 &NUMPUNS=1                     MAX NUMBER OF LOCAL PUNCHES              
-&NUMRDRS=1                     MAX NUMBER OF LOCAL READERS              
+&NUMRDRS=2                     MAX NUMBER OF LOCAL READERS              
 &NUMSMFB=96                    NUMBER OF SMF BUFFERS                    
 &NUMTGV=3330                   TRACK GROUPS PER SPOOL VOLUME (3350)     
 &OUTPOPT=0                     ACTION FOR JOBS EXCEEDING OUTPUT         
@@ -183,7 +183,8 @@ PUNCH1         CLASS=B,SEP,AUTO,NOPAUSE,UNIT=00D,START       2540P
 *********************************************************************** 
 *                              LOCAL READERS                          * 
 *********************************************************************** 
-READER1        AUTH=0,CLASS=A,NOHOLD,MSGCLASS=A,UNIT=00C     2540R      
+READER1        AUTH=0,CLASS=A,NOHOLD,MSGCLASS=A,UNIT=00C     2540R
+READER2        AUTH=0,CLASS=A,NOHOLD,MSGCLASS=A,UNIT=01A     2540R      
 &RECINCR=2                     RECORD ALTERNATION                       
 &RJOBOPT=5                     JOB CARD SCAN OPTION                     
 &RPRI(1)=6                     PRTY FOR ESTIMATED TIME                  


### PR DESCRIPTION
1 extra reader for the ebcdic reader

1 extra reader and punch because of the inactive ones causing errors on ipls 
e.g
0000 14.29.38           IEF196I $HASP412 MAXIMUM OF 2   READER(S)  EXCEEDED
FFFF 14.29.38           $HASP412 MAXIMUM OF 2   READER(S)  EXCEEDED
0000 14.29.38           IEF196I $HASP412 MAXIMUM OF 1   PUNCH(ES)  EXCEEDED
