### PR TITLE
Set correct permissions mask on start_mvs.sh

### DIFF
--- a/sysgen.py
+++ b/sysgen.py
@@ -2185,7 +2185,7 @@ class sysgen:
         with open(running_folder+"MVSCE/start_mvs.sh", 'w') as script:
             script.write("#!/bin/bash\nhercules -f conf/local.cnf -r conf/mvsce.rc -o hercules.log")
 
-        os.chmod(running_folder+"MVSCE/start_mvs.sh",755)
+        os.chmod(running_folder+"MVSCE/start_mvs.sh",33261)
 
         self.print("Cleanup Complete",color="GREEN")
 


### PR DESCRIPTION
See my comments on the original change for this. In brief, `os.chmod()` does NOT accept integers matching normal Linux/Unix permission masks. They're 5-digit integers corresponding to what looks to me like some weird ENUM. So, a `755` in Linux/Unix is a `33261` in a Python stat mask. 

You can confirm this by doing the following:

```
gmgauthier@plato $ touch blaff
[12:56:45][~/Projects/foss]
gmgauthier@plato $ ls -l blaff
-rw-r--r-- 1 gmgauthier gmgauthier 0 Mar 19 12:56 blaff
[12:56:52][~/Projects/foss]
gmgauthier@plato $ python3
Python 3.9.2 (default, Feb 28 2021, 17:03:44)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.stat('blaff').st_mode
33188
>>> quit()
[12:57:33][~/Projects/foss]
gmgauthier@plato $ chmod 755 blaff
[12:57:40][~/Projects/foss]
gmgauthier@plato $ ls -l blaff
-rwxr-xr-x 1 gmgauthier gmgauthier 0 Mar 19 12:56 blaff*
[12:57:44][~/Projects/foss]
gmgauthier@plato $ python3
Python 3.9.2 (default, Feb 28 2021, 17:03:44)
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.stat('blaff').st_mode
33261
>>>
```