### PR TITLE
step 12 doesn't checkpoint, add a checkpoint so restarting doesn't

### DIFF
--- a/sysgen.py
+++ b/sysgen.py
@@ -2126,6 +2126,7 @@ class sysgen:
         self.backup_dasd("35_ISPF")
 
     def step_12_cleanup(self):
+        self.set_step("step_12_cleanup")
         self.print("Step 12. Finalizing and Cleaning Up", color="CYAN")
 
         self.finalize()
@@ -2150,7 +2151,7 @@ class sysgen:
         Path(running_folder+"MVSCE/punchcards").mkdir(parents=True, exist_ok=True)
 
         self.print("Copying scripts to {}".format(Path(running_folder+"MVSCE/SCRIPTS").resolve()))
-        shutil.copytree(Path('SCRIPTS').resolve(), Path(running_folder+"MVSCE/SCRIPTS").resolve(),dirs_exist_ok=True)
+        shutil.copytree(Path('SCRIPTS').resolve(), Path(running_folder+"MVSCE/SCRIPTS").resolve())
 
         up = "| {:9} | {:8}|\n"
 


### PR DESCRIPTION
step_12_cleanup doesn't update the .step file, so if it fails, --CONTINUE restarts at step 11

For some reason, the copy tree step fails for me 100% of the time because "dirs_exist_ok" isn't valid for copytree. I don't know if this is specific to my python setup or what, but I can not complete a sysgen without this change, so submitting it for review.

Thanks!